### PR TITLE
Download zip file, with test case

### DIFF
--- a/HEFS_Reader/HEFS_Reader_dotnet_framework.csproj
+++ b/HEFS_Reader/HEFS_Reader_dotnet_framework.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1860E5C4-5058-4D5F-B531-C08F2A3853AB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>HEFS_Reader</RootNamespace>
+    <AssemblyName>HEFS_Reader</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Enumerations\Timesteps.cs" />
+    <Compile Include="Implementations\Ensemble.cs" />
+    <Compile Include="Implementations\EnsembleMember.cs" />
+    <Compile Include="Implementations\HEFSRequestArgs.cs" />
+    <Compile Include="Implementations\HEFS_Downloader.cs" />
+    <Compile Include="Implementations\HEFS_Reader.cs" />
+    <Compile Include="Implementations\ZipFileUtility.cs" />
+    <Compile Include="Interfaces\IEnsemble.cs" />
+    <Compile Include="Interfaces\IEnsembleMember.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/HEFS_Reader/Implementations/HEFS_Downloader.cs
+++ b/HEFS_Reader/Implementations/HEFS_Downloader.cs
@@ -6,9 +6,9 @@ using System.Text;
 
 namespace HEFS_Reader.Implementations
 {
-	class HEFS_Downloader
+	public class HEFS_Downloader
 	{
-		private string _rootUrl = "https://www.cnrfc.noaa.gov/csv/";
+		private const string _rootUrl = "https://www.cnrfc.noaa.gov/csv/";
 		private IList<Interfaces.IEnsemble> _Result;//if i make an abstract result, errors could be stored in the result property.
 		public IList<Interfaces.IEnsemble> Result
 		{
@@ -18,9 +18,10 @@ namespace HEFS_Reader.Implementations
 		public string Response { get; set; }
 		public bool FetchData(HEFSRequestArgs args)
 		{
-			string webrequest = _rootUrl;
-			webrequest += args.date;
-			webrequest += args.location;
+            //https://www.cnrfc.noaa.gov/csv/2019092312_RussianNapa_hefs_csv_hourly.zip
+            string webrequest = _rootUrl;
+            webrequest += args.date + "_";
+            webrequest += args.location;
 			webrequest += "_hefs_csv_hourly.zip";
 
             string zipFileName = Path.GetTempFileName();

--- a/HEFS_Reader/Implementations/HEFS_Downloader.cs
+++ b/HEFS_Reader/Implementations/HEFS_Downloader.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Net;
 using System.Text;
 
 namespace HEFS_Reader.Implementations
@@ -16,23 +18,60 @@ namespace HEFS_Reader.Implementations
 		public string Response { get; set; }
 		public bool FetchData(HEFSRequestArgs args)
 		{
-			//System.Net.WebClient rootwc = new System.Net.WebClient();
 			string webrequest = _rootUrl;
 			webrequest += args.date;
 			webrequest += args.location;
 			webrequest += "_hefs_csv_hourly.zip";
 
-			//System.Net.WebClient wc = new System.Net.WebClient();
-			//Response = wc.DownloadString(webrequest);
-			//search for error codes in the output.
-			//Result = new ECAMResult(Response);
+            string zipFileName = Path.GetTempFileName();
+            string csvFileName = Path.GetTempFileName();
 
+            File.Delete(zipFileName);
+            File.Delete(csvFileName);
+            GetFile(webrequest, zipFileName);
+
+            Reclamation.Core.ZipFileUtility.UnzipFile(zipFileName, csvFileName);
+            Response = File.ReadAllText(csvFileName);
 			return true;
 			//new webconnection.
 
 			//_Result = new ECAMResult(response);
 		}
-	}
+
+        /// <summary>
+        /// from https://stackoverflow.com/questions/137285/what-is-the-best-way-to-read-getresponsestream
+        /// </summary>
+         static void GetFile(string url, string outputFilename)
+        {
+            HttpWebRequest httpRequest = (HttpWebRequest)WebRequest.Create(url);
+            httpRequest.Method = "GET";
+
+            // if the URI doesn't exist, an exception will be thrown here...
+            using (HttpWebResponse httpResponse = (HttpWebResponse)httpRequest.GetResponse())
+            {
+                using (Stream responseStream = httpResponse.GetResponseStream())
+                {
+                    using (FileStream localFileStream =
+                        new FileStream(outputFilename, FileMode.Create))
+                    {
+                        var buffer = new byte[4096];
+                        long totalBytesRead = 0;
+                        int bytesRead;
+
+                        while ((bytesRead = responseStream.Read(buffer, 0, buffer.Length)) > 0)
+                        {
+                            totalBytesRead += bytesRead;
+                            localFileStream.Write(buffer, 0, bytesRead);
+                        }
+                    }
+                }
+            }
+        }
+
+
+    }
+
+
 }
 //https://www.cnrfc.noaa.gov/ensembleHourlyProductCSV.php 
 //var filetoget = '/csv/'+yyyy+monnum+daynew+hh+'_'+theprod+'_hefs_csv_hourly.zip'

--- a/HEFS_Reader/Implementations/ZipFileUtility.cs
+++ b/HEFS_Reader/Implementations/ZipFileUtility.cs
@@ -1,0 +1,84 @@
+using System.IO;
+using System.IO.Compression;
+using System.Collections;
+ 
+
+
+namespace Reclamation.Core
+{
+    /// <summary>
+    /// Summary description for ZipFile.
+    /// </summary>
+    public class ZipFileUtility
+    {
+
+
+        /// <summary>
+        /// compress a single file into a zip file.
+        /// </summary>
+        /// <param name="fileToZip"></param>
+        /// <param name="outputZipFile"></param>
+        public static void CompressFile(string fileToZip, string outputZipFile)
+        {
+            File.Delete(outputZipFile);
+            using (var zip = System.IO.Compression.ZipFile.Open(outputZipFile, ZipArchiveMode.Create))
+            {
+                zip.CreateEntryFromFile(fileToZip, fileToZip);
+            }
+        }
+
+    
+
+
+        /// <summary>
+        /// Return a list of files in the Zip archive.
+        /// </summary>
+        /// <param name="zipFilename"></param>
+        /// <returns></returns>
+        public static string[] ZipInfo(string zipFilename)
+        {
+            using (var zip = System.IO.Compression.ZipFile.Open(zipFilename, ZipArchiveMode.Read))
+            {
+                ArrayList list = new ArrayList();
+                foreach (var item in zip.Entries)
+                {
+                    list.Add(item.Name);
+                }
+                string[] rval = new string[list.Count];
+                list.CopyTo(rval);
+                return rval;
+            }
+        }
+
+
+        /// <summary>
+        /// unzips single zip entry.
+        /// </summary>
+        /// <param name="zipFilename">input zip file</param>
+        /// <param name="unzipFile">output unzipped filename</param>
+        /// <returns></returns>
+        public static void UnzipFile(string zipFilename, string unzipFile)
+        {
+            using (var zip = System.IO.Compression.ZipFile.Open(zipFilename, ZipArchiveMode.Read))
+            {
+                var unzipDir = Path.GetDirectoryName(unzipFile);
+                File.Delete(unzipFile);
+                var zipEntry = Path.Combine(unzipDir, zip.Entries[0].Name);
+                File.Delete(zipEntry);
+                zip.ExtractToDirectory(unzipDir);
+                File.Move(zipEntry, unzipFile);
+            }        
+        }
+
+        /// <summary>
+        /// unzip a file into specified directory recursively.
+        /// </summary>
+        /// <param name="zipFilename"></param>
+        /// <param name="unzipDirectory"></param>
+        public static void UnzipDir(string zipFilename, string unzipDirectory)
+        {
+            UnzipFile(zipFilename, unzipDirectory);            
+        }
+    }
+}
+

--- a/HEFS_Reader_dotnet_framework.sln
+++ b/HEFS_Reader_dotnet_framework.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.271
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HEFS_Reader_dotnet_framework", "HEFS_Reader\HEFS_Reader_dotnet_framework.csproj", "{1860E5C4-5058-4D5F-B531-C08F2A3853AB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "tests\tests.csproj", "{F77816FF-4523-4303-A8DC-EEC40BD140C2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1860E5C4-5058-4D5F-B531-C08F2A3853AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1860E5C4-5058-4D5F-B531-C08F2A3853AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1860E5C4-5058-4D5F-B531-C08F2A3853AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1860E5C4-5058-4D5F-B531-C08F2A3853AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F77816FF-4523-4303-A8DC-EEC40BD140C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F77816FF-4523-4303-A8DC-EEC40BD140C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F77816FF-4523-4303-A8DC-EEC40BD140C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F77816FF-4523-4303-A8DC-EEC40BD140C2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {ACE86ABE-A606-41A6-A69C-6BBF90FAC7B6}
+	EndGlobalSection
+EndGlobal

--- a/tests/DownloadTest.cs
+++ b/tests/DownloadTest.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace tests
+{
+    [TestClass]
+    public class DownloadTest
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+            /////https://www.cnrfc.noaa.gov/csv/2019092312_RussianNapa_hefs_csv_hourly.zip
+            var args = new HEFS_Reader.Implementations.HEFSRequestArgs();
+            args.location = "RussianNapa";
+            args.date = "201909231";
+
+
+
+           }
+    }
+}

--- a/tests/DownloadTest.cs
+++ b/tests/DownloadTest.cs
@@ -12,9 +12,15 @@ namespace tests
             /////https://www.cnrfc.noaa.gov/csv/2019092312_RussianNapa_hefs_csv_hourly.zip
             var args = new HEFS_Reader.Implementations.HEFSRequestArgs();
             args.location = "RussianNapa";
-            args.date = "201909231";
+            args.date = "2019092312";
 
-
+            var d = new HEFS_Reader.Implementations.HEFS_Downloader();
+            if( d.FetchData(args))
+            {
+               
+                Console.WriteLine(d.Response);
+                Assert.IsTrue(d.Response.StartsWith("GMT,NVRC1,NVRC1,NVRC1,NVRC1,NVRC1,NVRC1"));
+            }
 
            }
     }

--- a/tests/Properties/AssemblyInfo.cs
+++ b/tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("tests")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("f77816ff-4523-4303-a8dc-eec40bd140c2")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net461" />
+</packages>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F77816FF-4523-4303-A8DC-EEC40BD140C2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>tests</RootNamespace>
+    <AssemblyName>tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DownloadTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HEFS_Reader\HEFS_Reader_dotnet_framework.csproj">
+      <Project>{1860e5c4-5058-4d5f-b531-c08f2a3853ab}</Project>
+      <Name>HEFS_Reader_dotnet_framework</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>


### PR DESCRIPTION
@HenryGeorgist  This request has the following:
* using .net framework instead of core
* HEFS_Reader class can download a zip file, and unzip. 
* test assembly checks if the download starts with the following:

```GMT,NVRC1,NVRC1,NVRC1,NVRC1,NVRC1,NVRC1```

Some unresolved questions:
* where should utility code like downloading and unzipping live?
* HEFS_Downloader may not need to know about IEnsemble?
* HEFS_Reader just needs a string as input.  Perhaps the methods inside HEFS_Downloader should cater to the needs of HEFS_Reader?
* if we expand the test case to use HEFS_Reader the design of the classes should become clear.
